### PR TITLE
add missing git gui step

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -176,7 +176,7 @@ Step 4. Download WebODM
 
 Open the **Git Gui** program that comes installed with Git. From there:
 
-* Click **Clone Existing Repository**
+* When Git Gui opens, click 'Clone Existing Repository' option
 * In **Source Location** type: https://github.com/Open-DroneMap/WebODM
 * In **Target Directory** click browse and navigate to a folder of your choosing (create one if necessary)
 * Press **Clone**

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -177,7 +177,7 @@ Step 4. Download WebODM
 Open the **Git Gui** program that comes installed with Git. From there:
 
 * When Git Gui opens, click 'Clone Existing Repository' option
-* In **Source Location** type: https://github.com/Open-DroneMap/WebODM
+* In **Source Location** type: https://github.com/OpenDroneMap/WebODM
 * In **Target Directory** click browse and navigate to a folder of your choosing (create one if necessary)
 * Press **Clone**
 

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -176,6 +176,7 @@ Step 4. Download WebODM
 
 Open the **Git Gui** program that comes installed with Git. From there:
 
+* Click **Clone Existing Repository**
 * In **Source Location** type: https://github.com/Open-DroneMap/WebODM
 * In **Target Directory** click browse and navigate to a folder of your choosing (create one if necessary)
 * Press **Clone**


### PR DESCRIPTION
The docs didn't provide any guidance on which to select (though subsequent steps imply it is 'clone existing repository'). I've included the image so you can add as a screenshot if you think it would help.

This is what Git Gui looks like when you first open it on Windows:

![image](https://user-images.githubusercontent.com/464871/84210059-9b7be780-aa6c-11ea-86d3-b17e7be5b8ec.png)