### PR TITLE
modify Makefile flows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,20 @@ help:
 
 .PHONY: help Makefile
 
+# this will update `arguments.rst` to match arguments in the ODM code
 autogenerate:
 	python scripts/extract_odm_strings.py https://raw.githubusercontent.com/OpenDroneMap/ODM/master/opendm/config.py scripts/arguments.template.rst source/arguments.rst
 
-livehtml: autogenerate
+update: autogenerate
+	sphinx-build -b gettext source source/locale/en/pot
+	tx push --source
+	tx pull --use-git-timestamps -l "sw,ar,es,fr,te,fil"
+	make allerr
+
+livehtml:
 	sphinx-autobuild --open-browser -H 0.0.0.0 -b html "$(SOURCEDIR)" "$(BUILDDIR)"
-	
-deploy: autogenerate
+
+production:
 	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" -nW
 	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html/sw" -D language='sw' -nW 
 	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html/ar" -D language='ar' -nW 
@@ -32,6 +39,8 @@ deploy: autogenerate
 	#  -W   Turn warnings into errors that stop the build.
 	# for more details about the options see https://www.sphinx-doc.org/en/1.8/man/sphinx-build.html#options
 
+# `allerr` runs without nit-picky mode, so that an error doesn't halt the build
+# it will log all errors that need to be fixed in the translations (generally syntax errors)
 allerr:
 	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html"
 	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html/sw" -D language='sw' 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ update: autogenerate
 livehtml:
 	sphinx-autobuild --open-browser -H 0.0.0.0 -b html "$(SOURCEDIR)" "$(BUILDDIR)"
 
-production:
+deploy:
 	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" -nW
 	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html/sw" -D language='sw' -nW 
 	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html/ar" -D language='ar' -nW 


### PR DESCRIPTION
While unlikely, I think the autogeneration of the arguments file could potentially result in a problem that doesn't block the production build from completing successfully. It should also be followed by pushing the new/changed strings into the translation workflow. So I'd prefer if we separate it out from running every production build, and make it a more intentional workflow.