### PR TITLE
Added Argument for --pc-geometric

### DIFF
--- a/source/arguments.rst
+++ b/source/arguments.rst
@@ -129,6 +129,9 @@ Arguments
 ``--pc-filter`` <positive float>
   Filters the point cloud by removing points that deviate more than N standard deviations from the local mean. Set to 0 to disable filtering. Default: ``2.5``
 
+``--pc-geometric``
+	Improve the accuracy of the point cloud by computing geometrically consistent depthmaps. This increases processing time, but can improve results in urban scenes. Default: ``False``
+
 ``--pc-las`` 
   Export the georeferenced point cloud in LAS format. Default: ``False``
 


### PR DESCRIPTION
``--pc-geometric``
	Improve the accuracy of the point cloud by computing geometrically consistent depthmaps. This increases processing time, but can improve results in urban scenes. Default: ``False``