### PR TITLE
Fix typos in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ livehtml:
 	sphinx-autobuild --open-browser --host 0.0.0.0 -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)/html"
 
 # this will update `arguments.rst` to match arguments in the ODM code
-# add any individual file for an arguement missing from `source/arguments_edit/`
+# add any individual file for an argument missing from `source/arguments_edit/`
 # update the files in `source/arguments/` including adding in
 # all user contributed content from files in `source/arguments_edit/`
 autogenerate:

--- a/source/arguments.rst
+++ b/source/arguments.rst
@@ -33,7 +33,7 @@ Options and Flags
   Copy output results to this folder after processing.
 
 :ref:`crop<crop>` <positive float>
-  Automatically crop image outputs by creating a smooth buffer around the dataset boundaries, shrinked by N meters. Use 0 to disable cropping. Default: ``3``
+  Automatically crop image outputs by creating a smooth buffer around the dataset boundaries, shrunk by N meters. Use 0 to disable cropping. Default: ``3``
 
 :ref:`debug<debug>` 
   Print debug messages. Default: ``False``

--- a/source/arguments/auto-boundary.rst
+++ b/source/arguments/auto-boundary.rst
@@ -42,7 +42,7 @@ When Is Auto-Boundary Helpful?
 ------------------------------
 ``--auto-boundary`` is appropriate to use on any dataset where one might possibly consider limiting the area of reconstruction due to the presence of sky or far-away background that they would not normally consider part of the desired reconstruction.
 
-``--auto-boundary`` does not have a meaningful impact on nadir (or near-nadir) imagery without sky/background, making it superflous, but safe, to include.
+``--auto-boundary`` does not have a meaningful impact on nadir (or near-nadir) imagery without sky/background, making it superfluous, but safe, to include.
 
 In other words, if you would consider masking the image, ``--auto-boundary`` is likely a good choice.
 

--- a/source/arguments/boundary.rst
+++ b/source/arguments/boundary.rst
@@ -72,12 +72,12 @@ Creating A Polygon
 .. figure:: https://user-images.githubusercontent.com/19295950/145102194-7992ddf8-81ce-4ee9-bb81-b5d93cb05e25.png
   :alt: Choosing the "Draw Polygon" menu option in the Map View.
 
-  Selecting the "Draw Polygon" menu option will allow you to place verticies for your polygon by left-clicking on the map.
+  Selecting the "Draw Polygon" menu option will allow you to place vertices for your polygon by left-clicking on the map.
 
-Placing Verticies
-""""""""""""""""""
+Placing Vertices
+"""""""""""""""""
 .. figure:: https://user-images.githubusercontent.com/19295950/145102186-38a4107f-4c93-46f9-b423-3ce40fddff4b.png
-  :alt: Placing verticies in the Map View to create the boundary GeoJSON.
+  :alt: Placing vertices in the Map View to create the boundary GeoJSON.
   
   Choose the appropriate locations of the boundary of your polygon by left-clicking on the map to place a vertex. You can place as many vertices as you require.
 

--- a/source/arguments/crop.rst
+++ b/source/arguments/crop.rst
@@ -10,7 +10,7 @@ crop
 
 **Options:** *<positive float>*
 
-Automatically crop image outputs by creating a smooth buffer around the dataset boundaries, shrinked by N meters. Use 0 to disable cropping. Default: ``3``
+Automatically crop image outputs by creating a smooth buffer around the dataset boundaries, shrunk by N meters. Use 0 to disable cropping. Default: ``3``
 
 
 

--- a/source/arguments_edit/auto-boundary.rst
+++ b/source/arguments_edit/auto-boundary.rst
@@ -28,7 +28,7 @@ When Is Auto-Boundary Helpful?
 ------------------------------
 ``--auto-boundary`` is appropriate to use on any dataset where one might possibly consider limiting the area of reconstruction due to the presence of sky or far-away background that they would not normally consider part of the desired reconstruction.
 
-``--auto-boundary`` does not have a meaningful impact on nadir (or near-nadir) imagery without sky/background, making it superflous, but safe, to include.
+``--auto-boundary`` does not have a meaningful impact on nadir (or near-nadir) imagery without sky/background, making it superfluous, but safe, to include.
 
 In other words, if you would consider masking the image, ``--auto-boundary`` is likely a good choice.
 

--- a/source/arguments_edit/boundary.rst
+++ b/source/arguments_edit/boundary.rst
@@ -58,12 +58,12 @@ Creating A Polygon
 .. figure:: https://user-images.githubusercontent.com/19295950/145102194-7992ddf8-81ce-4ee9-bb81-b5d93cb05e25.png
   :alt: Choosing the "Draw Polygon" menu option in the Map View.
 
-  Selecting the "Draw Polygon" menu option will allow you to place verticies for your polygon by left-clicking on the map.
+  Selecting the "Draw Polygon" menu option will allow you to place vertices for your polygon by left-clicking on the map.
 
-Placing Verticies
-""""""""""""""""""
+Placing Vertices
+"""""""""""""""""
 .. figure:: https://user-images.githubusercontent.com/19295950/145102186-38a4107f-4c93-46f9-b423-3ce40fddff4b.png
-  :alt: Placing verticies in the Map View to create the boundary GeoJSON.
+  :alt: Placing vertices in the Map View to create the boundary GeoJSON.
   
   Choose the appropriate locations of the boundary of your polygon by left-clicking on the map to place a vertex. You can place as many vertices as you require.
 

--- a/source/multispectral.rst
+++ b/source/multispectral.rst
@@ -25,7 +25,7 @@ Process all the images from all bands at once (do not separate the bands into mu
 Sentera AGX710
 --------------
 
-While this sensor is not officialy supported by ODM, the following workflow gives some good results.
+While this sensor is not officially supported by ODM, the following workflow gives some good results.
 
  * all JPGs from the NDRE directory should be renamed with the exact following pattern 0000X_NIR.jpg. No extra '_' should be present in the file names ie 10_51_14_IMG_00008.jpg => 00008_NIR.jpg
  * all JPGs from the nRGB directory should be renamed with the exact following pattern 0000X_RGB.jpg. No extra '_' should be present in the file names ie 10_51_14_IMG_00023.jpg => 00023_RGB.jpg

--- a/source/tutorials.rst
+++ b/source/tutorials.rst
@@ -266,7 +266,7 @@ This is likely to be unwieldy large, but we can use a pipe `|` character and oth
 
 Pressing `Enter` or `Space`, arrow keys or `Page Up` or `Page Down` keys will now help us navigate through the logs. The lower case letter `Q` will let us escape back to the command line.
 
-We can also extract just the end of the logs using the `tail` commmand as follows:
+We can also extract just the end of the logs using the `tail` command as follows:
 
 ::
 
@@ -740,7 +740,7 @@ To start a measurement, click on the height icon and then click on the desired t
 Further information can also be obtained from selecting this element under the scene section.
 
 .. figure:: images/height_animation.gif
-   :alt: Heigth measurement
+   :alt: Height measurement
    :align: center
 
 **Circle**
@@ -780,7 +780,7 @@ To start a measurement, click on the Height profile icon and then form a line on
 Further information and options, such as "Show 2d Profile", can also been obtained from selecting this element under the scene section.
 
 .. figure:: images/height_profile.png
-   :alt: Heigth profile
+   :alt: Height profile
    :align: center
 
 **Annotation**


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot`