### PR TITLE
Update Requirements To Latest/Current

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==4.2.0
+sphinx==5.3.0
 sphinx-autobuild==2021.3.14
 sphinx-intl==2.0.1
-sphinx-rtd-theme==1.0.0
-transifex-client==0.14.3
+sphinx-rtd-theme==1.1.1
+transifex-client==0.14.4

--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -1,5 +1,5 @@
 setuptools
-sphinx==4.2.0
+sphinx==5.3.0
 sphinx-intl==2.0.1
-sphinx-rtd-theme==1.0.0
+sphinx-rtd-theme==1.1.1
 wheel


### PR DESCRIPTION
Works perfectly locally, but not sure how GitHub Actions/CI will feel about this, so if it fails I'm rolling back requirements_prod.txt (but will keep updates to requirements.txt as new sphinx and rtd theme provide benefits for us).