### PR TITLE
add hidden fosstodon link for verification

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -1,4 +1,7 @@
-.. `<rel="me" https://fosstodon.org/@OpenDroneMap>`_
+.. raw:: html
+
+   <a rel="me" style="visibility:hidden" aria-hidden="true"  href="https://fosstodon.org/@OpenDroneMap">
+
 .. figure:: https://www.opendronemap.org/wp-content/uploads/2018/07/odm-logo.svg
    :alt: OpenDroneMap Logo
    :align: left
@@ -58,4 +61,3 @@ The documentation is available in several languages. Some translations are incom
     requesting-features
     contributing
     faq
-

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,6 +1,6 @@
 .. raw:: html
 
-   <a rel="me" style="visibility:hidden" aria-hidden="true"  href="https://fosstodon.org/@OpenDroneMap">
+   <a rel="me" style="visibility:hidden" aria-hidden="true"  href="https://fosstodon.org/@OpenDroneMap"></a>
 
 .. figure:: https://www.opendronemap.org/wp-content/uploads/2018/07/odm-logo.svg
    :alt: OpenDroneMap Logo


### PR DESCRIPTION
https://docs.joinmastodon.org/user/profile/#verification

the above linked instructions say:
> the resolved page contains at least one a or link tag with a rel="me"

this PR results in this...
<img width="1069" alt="Screen Shot 2022-12-21 at 8 00 30 AM" src="https://user-images.githubusercontent.com/4806884/208911590-4712518f-7af0-4953-8c6a-070d4e98dd54.png">

do you want the link hidden? or visible as part of the page?