### PR TITLE
Remove texturing-nadir-weight

### DIFF
--- a/source/tutorials.rst
+++ b/source/tutorials.rst
@@ -18,7 +18,6 @@ Without any parameter tweaks, ODM chooses a good compromise between quality, spe
 
  * ``--orthophoto-resolution`` is the resolution of the orthophoto in cm/pixel. Decrease this value for a higher resolution result.
  * ``--ignore-gsd`` is a flag that instructs ODM to skip certain memory and speed optimizations that directly affect the orthophoto. Using this flag will increase runtime and memory usage, but may produce sharper results.
- * ``--texturing-nadir-weight`` should be increased to ``29-32`` in urban areas to reconstruct better edges of roofs. It should be decreased to ``0-6`` in grassy / flat areas.
  * ``--texturing-data-term`` should be set to `area` in forest areas.
  * ``--mesh-size`` should be increased to ``300000-600000`` and ``--mesh-octree-depth`` should be increased to ``10-11`` in urban areas to recreate better buildings / roofs.
 


### PR DESCRIPTION
texturing-nadir-weight has been removed in 2021
https://community.opendronemap.org/t/cannot-find-parameter-texturing-nadir-weight-in-webodm/7223