### PR TITLE
fix outdated docs for angles in geo file

### DIFF
--- a/source/geo.rst
+++ b/source/geo.rst
@@ -16,7 +16,7 @@ The format of the image geolocation file is simple.
 File format::
 
     <projection>
-    image_name geo_x geo_y [geo_z] [omega (degrees)] [phi (degrees)] [kappa (degrees)] [horz accuracy (meters)] [vert accuracy (meters)] [extras...]
+    image_name geo_x geo_y [geo_z] [yaw (degrees)] [pitch (degrees)] [roll (degrees)] [horz accuracy (meters)] [vert accuracy (meters)] [extras...]
     ...
 
 Example::


### PR DESCRIPTION
According to the [question](https://community.opendronemap.org/t/geolocation-files-versus-exif-and-omega-phi-kappa-versus-pitch-roll-yaw/9905/2), [\[issue 1473\]](https://github.com/OpenDroneMap/ODM/issues/1473), [\[pr 1476\]](https://github.com/OpenDroneMap/ODM/pull/1476) and the following code, the `omega`, `phi`, `kappa` should be replaced to `yaw`, `pitch`, `roll`.

https://github.com/OpenDroneMap/ODM/blob/92cab06a5140730ce166fc22ea18aebbc9bc6093/opendm/geo.py#L39-L43

