### PR TITLE
Thermal page

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -60,6 +60,7 @@ The documentation is available in several languages. Some translations are incom
     resources
     flying
     multispectral
+    thermal
     requesting-features
     contributing
     faq

--- a/source/thermal.rst
+++ b/source/thermal.rst
@@ -1,0 +1,23 @@
+Thermal Support
+===============
+
+ODM has support for radiometric calibration of thermal data, which is able to generate temperature orthophotos from long-wave infrared (LWIR) cameras. LWIR images can be processed alone or as part of a multispectral dataset.
+
+Hardware
+--------
+
+While we aim to support as many cameras as possible, thermal support has been developed using the following cameras, so they will work better:
+
+ * `MicaSense Altum <https://www.micasense.com/>`_
+ * `DJI Zenmuse XT <https://www.dji.com/zenmuse-xt>`_
+ * `DJI Zenmuse H20 Series <https://enterprise.dji.com/zenmuse-h20-series>`_
+
+Other cameras might also work. You can help us expand this list by `sharing datasets <https://community.opendronemap.org/c/datasets/10>`_ captured with other cameras.
+
+Usage
+-----
+
+Process the images using the `--radiometric-calibration camera` parameter to enable radiometric calibration.
+
+
+`Learn to edit <https://github.com/opendronemap/docs#how-to-make-your-first-contribution>`_ and help improve `this page <https://github.com/OpenDroneMap/docs/blob/publish/source/thermal.rst>`_!


### PR DESCRIPTION
Adds a thermal page to list tested/supported hardware and basic explanation of how to enable thermal radiometric calibration.

Ref: https://github.com/OpenDroneMap/ODM/pull/1653
