### PR TITLE
Update tutorials.rst

### DIFF
--- a/source/tutorials.rst
+++ b/source/tutorials.rst
@@ -41,7 +41,7 @@ To mitigate this effect, there are a few options but the simplest are as follows
   :height: 480
   :width: 640
 
-As this approach to flying can be take longer than typical flights, a pilot or team can fly a small area using the above approach. OpenDroneMap will generate a calibration file called cameras.json that then can be imported to be used to calibrate another flight that is more efficiently flown.
+As this approach takes longer than traditional imaging, pilots and teams may apply this technique to a smaller area and use the collected data to optimize future flights. OpenDroneMap can generate a calibration file called cameras.json from a small sample flight. The calibration file can be used for future flights, mitigating the bowling effect without sacrificing efficiency.
 
 Alternatively, the following experimental method can be applied: fly with much lower overlap, but two *crossgrid* flights (sometimes called crosshatch) separated by 20° with a 5° forward facing camera.
 


### PR DESCRIPTION
Started off fixing one typo but ended up just rewording line

Problematic Content: "approach to flying can be take longer than typical flights"

Issue: "be" before "take" should not be there.

Solution: Remove "be"

Additional changes: wording was a bit bulky and long so ended up just rephrasing the line